### PR TITLE
Fixed depraction warnings, added api for just getting the numpy array

### DIFF
--- a/deepfakeecg/__init__.py
+++ b/deepfakeecg/__init__.py
@@ -1,2 +1,2 @@
 from deepfakeecg.models import Generator
-from deepfakeecg.deepfakeecg import generate
+from deepfakeecg.deepfakeecg import generate, generate_as_numpy

--- a/deepfakeecg/deepfakeecg.py
+++ b/deepfakeecg/deepfakeecg.py
@@ -4,37 +4,80 @@ import numpy as np
 from tqdm import tqdm
 from . import Generator
 from pathlib import Path
+from typing import Union, Literal
 
 
+def generate(num_of_sample: int, out_dir: Union[str, Path], start_id: int = 0, run_device: Literal["cpu", "cuda"] = "cpu") -> None:
+    """Generate multiple 8-lead ECG waveforms and save them as ASCII files
 
+    Args:
+        num_of_sample (int): Number of ECG samples to generate
+        out_dir (Union[str, Path]): Output directory path where files will be saved
+        start_id (int): Starting ID for the generated samples
+        run_device (Literal["cpu", "cuda"]): Device to run generation on ("cpu" or "cuda")
 
-
-def generate(num_of_sample, out_dir, start_id=0, run_device="cpu"):
-
-    # Testing
+    Returns:
+        None: Files are saved to the specified output directory with names {start_id}.asc to {start_id + num_of_sample - 1}.asc
+             Each file contains ECG data in ASCII format with shape (5000, 8) for leads [I, II, V1, V2, V3, V4, V5, V6]
+    """
     root_dir = Path(__file__).parent
 
     device = torch.device(run_device)
 
     netG = Generator()
-    checkpoint= torch.load(os.path.join(root_dir, "checkpoints/g_stat.pt"), map_location=device)
+    checkpoint = torch.load(
+        os.path.join(root_dir, "checkpoints/g_stat.pt"),
+        map_location=device,
+        weights_only=True
+    )
     netG.load_state_dict(checkpoint["stat_dict"])
     netG.to(device)
     netG.eval()
-   
 
-    for i in tqdm(range(start_id, start_id  + num_of_sample)):
+    for i in tqdm(range(start_id, start_id + num_of_sample)):
         noise = torch.Tensor(1, 8, 5000).uniform_(-1, 1)
         noise = noise.to(device)
         out = netG(noise)
-        out_rescaled = out*6000
-        out_rescaled =out_rescaled.int()
-        
-       
+        out_rescaled = out * 6000
+        out_rescaled = out_rescaled.int()
+
         out_rescaled_t = torch.t(out_rescaled.squeeze())
 
-        #asc_file = open("{}/{}.asc".format(asc_dir, i), 'ab')
-        np.savetxt("{}/{}.asc".format(out_dir,str(i)), out_rescaled_t.detach().cpu().numpy(), fmt='%i')
-        #asc_file.close()
+        # asc_file = open("{}/{}.asc".format(asc_dir, i), 'ab')
+        np.savetxt("{}/{}.asc".format(out_dir, str(i)), out_rescaled_t.detach().cpu().numpy(), fmt='%i')
+        # asc_file.close()
 
 
+def generate_as_numpy(run_device="cpu"):
+    """Generate a single 8-lead ECG waveform using deepfakeecg model
+
+    Args:
+        run_device (str): Device to run generation on ("cpu" or "cuda")
+
+    Returns:
+        numpy.ndarray: Array of shape (5000, 8) containing the ECG data
+                      for leads [I, II, V1, V2, V3, V4, V5, V6]
+    """
+    root_dir = Path(__file__).parent
+    device = torch.device(run_device)
+
+    netG = Generator()
+    checkpoint = torch.load(
+        os.path.join(root_dir, "checkpoints/g_stat.pt"),
+        map_location=device,
+        weights_only=True
+    )
+    netG.load_state_dict(checkpoint["stat_dict"])
+    netG.to(device)
+    netG.eval()
+
+    noise = torch.Tensor(1, 8, 5000).uniform_(-1, 1)
+    noise = noise.to(device)
+    out = netG(noise)
+    out_rescaled = out * 6000
+    out_rescaled = out_rescaled.int()
+
+    # Convert to numpy and transpose to get (5000, 8) shape
+    data = out_rescaled.squeeze().t().detach().cpu().numpy()
+
+    return data

--- a/examples/generate_as_numpy.py
+++ b/examples/generate_as_numpy.py
@@ -1,0 +1,21 @@
+import matplotlib.pyplot as plt
+import deepfakeecg
+import numpy as np
+
+# Generate a single ECG sample
+ecg_data = deepfakeecg.generate_as_numpy(run_device="cpu")
+
+# Plot the first lead (Lead I)
+plt.figure(figsize=(15, 3))
+plt.plot(ecg_data[:, 0])
+plt.title("Generated ECG - Lead I")
+plt.xlabel("Sample")
+plt.ylabel("Amplitude (μV)")
+plt.grid(True)
+
+# Print shape and basic stats
+print(f"ECG data shape: {ecg_data.shape}")
+print(f"Value range: [{np.min(ecg_data)}, {np.max(ecg_data)}]")
+print("\nLead order: [I, II, V1, V2, V3, V4, V5, V6]")
+
+plt.show()

--- a/examples/generate_to_file.py
+++ b/examples/generate_to_file.py
@@ -1,0 +1,19 @@
+from deepfakeecg import generate
+import os
+
+# Create output directory if it doesn't exist
+output_dir = "generated_ecgs"
+os.makedirs(output_dir, exist_ok=True)
+
+# Generate 5 ECG samples starting from ID 0
+generate(
+    num_of_sample=5,
+    out_dir=output_dir,
+    start_id=0,
+    run_device="cpu"
+)
+
+print(f"Generated 5 ECG samples in {output_dir}")
+print("Files generated:")
+for file in os.listdir(output_dir)[:5]:
+    print(f" - {file}")

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,8 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 setuptools.setup(
-    name="deepfake-ecg", # Replace with your own username
-    version="1.1.2",
+    name="deepfake-ecg",  # Replace with your own username
+    version="1.1.3",
     author="Vajira Thambawita",
     author_email="vlbthambawita@gmail.com",
     description="Unlimited 10-sec 8-leads Deep Fake ECG generator.",
@@ -25,5 +25,9 @@ setuptools.setup(
         'numpy',
         'tqdm',
         'pandas',
-  ],
+        'torch',
+    ],
+    extras_require={
+        'examples': ['matplotlib'],
+    },
 )


### PR DESCRIPTION
## Major changes

### Fixed 'Deprecation' Warnings

Running the code as of now produces the below errors:

```python
FutureWarning: `nn.init.kaiming_normal` is now deprecated in favor of `nn.init.kaiming_normal_`.nn.init.kaiming_normal(m.weight.data)
```

```python
FutureWarning: You are using `torch.load` with `weights_only=False` (the current default value), which uses the default pickle module implicitly. It is possible to construct malicious pickle data which will execute arbitrary code during unpickling (See https://github.com/pytorch/pytorch/blob/main/SECURITY.md#untrusted-models for more details). In a future release, the default value for `weights_only` will be flipped to `True`. This limits the functions that could be executed during unpickling. Arbitrary objects will no longer be allowed to be loaded via this mode unless they are explicitly allowlisted by the user via `torch.serialization.add_safe_globals`. We recommend you start setting `weights_only=True` for any use case where you don't have full control of the loaded file. Please open an issue on GitHub for any issues related to this experimental feature.
  checkpoint = torch.load(os.path.join(root_dir, "checkpoints/g_stat.pt"), map_location=device)
```

This PR fixes these, also alongisde them an extra API is added to retrive the generated ECG data as numpy instead of writing to a file.

## Minor Changes
* Added docs and types for the main API
* Added examples to test the API


