### PR TITLE
Dependency fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 requires-python = ">=3.7"
 dependencies = [
     "numpy",
+    "matplotlib",
     "tqdm",
     "pandas",
     "torch"


### PR DESCRIPTION
generate_as_numpy.py requires matplotlib, which must be defined as a dependency in pyproject.toml.