### PR TITLE
Improved export of generated ECGs with configurable options

### DIFF
--- a/deepfakeecg/__init__.py
+++ b/deepfakeecg/__init__.py
@@ -1,2 +1,39 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# ==========================================================================
+#         ____                   __       _          _____ ____ ____
+#        |  _ \  ___  ___ _ __  / _| __ _| | _____  | ____/ ___/ ___|
+#        | | | |/ _ \/ _ \ '_ \| |_ / _` | |/ / _ \ |  _|| |  | |  _
+#        | |_| |  __/  __/ |_) |  _| (_| |   <  __/ | |__| |__| |_| |
+#        |____/ \___|\___| .__/|_|  \__,_|_|\_\___| |_____\____\____|
+#                        |_|
+#
+#                       --- Deepfake ECG Generator ---
+#                https://github.com/vlbthambawita/deepfake-ecg
+# ==========================================================================
+#
+# Generator Library
+# Copyright (C) 2021-2025 by Vajira Thambawita
+# Copyright (C) 2021-2025 by Turtle <erencemayez@gmail.com>
+# Copyright (C) 2025 by Thomas Dreibholz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Contact:
+# * Vajira Thambawita <vlbthambawita@gmail.com>
+# * Turtle <erencemayez@gmail.com>
+# * Thomas Dreibholz <dreibh@simula.no>
+
 from deepfakeecg.models      import Generator
 from deepfakeecg.deepfakeecg import *

--- a/deepfakeecg/__init__.py
+++ b/deepfakeecg/__init__.py
@@ -1,2 +1,2 @@
-from deepfakeecg.models import Generator
-from deepfakeecg.deepfakeecg import generate, generate_as_numpy
+from deepfakeecg.models      import Generator
+from deepfakeecg.deepfakeecg import *

--- a/deepfakeecg/deepfakeecg.py
+++ b/deepfakeecg/deepfakeecg.py
@@ -98,6 +98,7 @@ def generateDeepfakeECGs(numberOfECGs:       int = 1,
          OUTPUT_PDF: PDF, with plot of the output
       outputFilePattern: Pattern for naming output files, with format() placeholder 'number', e.g. 'ecg-{number:06d}.csv'
       outputStartID: Start ID for file numbering
+      outputLeads: List of output leads for PDF plotting (from: [ 'I', 'II', 'III', 'aVL', 'aVR', 'aVF', 'V1', 'V2', 'V3', 'V4', 'V5', 'V6' ])
       runOnDevice (str): Device to run generation on ('cpu' or 'cuda')
 
    Returns:

--- a/deepfakeecg/deepfakeecg.py
+++ b/deepfakeecg/deepfakeecg.py
@@ -117,7 +117,7 @@ def generateDeepfakeECGs(numberOfECGs:       int = 1,
    results = [ ]
    for i in tqdm.tqdm(range(outputStartID, outputStartID + numberOfECGs)):
       # ------ Create random noise  -----------------------------------------
-      noise = torch.Tensor(1, 8, ecgLengthInSamples, device = device).uniform_(-1, 1)
+      noise = torch.empty(1, 8, ecgLengthInSamples, device = device).uniform_(-1, 1)
 
       # ------ Generate ECG -------------------------------------------------
       generatedECG = generator(noise)

--- a/deepfakeecg/deepfakeecg.py
+++ b/deepfakeecg/deepfakeecg.py
@@ -41,13 +41,13 @@ import pathlib
 import sys
 import torch
 import tqdm
-from typing  import Union, Literal
+import typing
 
 from . import Generator
 
 
 # ------ Constants ----------------------------------------
-ECG_SAMPLING_RATE = 500
+ECG_SAMPLING_RATE = 500   # in Hz
 
 # ------ ECG types ----------------------------------------
 DATA_ECG8         = 8
@@ -64,9 +64,9 @@ def generateDeepfakeECGs(numberOfECGs:       int = 1,
                          ecgType:            int = DATA_ECG8,
                          ecgLengthInSeconds: int = 10,
                          outputFormat:       int = OUTPUT_NUMPY,
-                         outputFilePattern:  Union[str, pathlib.Path] = None,
+                         outputFilePattern:  typing.Union[str, pathlib.Path] = None,
                          outputStartID:      int = 0,
-                         runOnDevice:        Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu"):
+                         runOnDevice:        typing.Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu"):
    """Generate ECG waveforms using deepfakeecg model, with configurable
       data type (8-lead or 12-lead ECG) and output type (numpy, file).
 
@@ -183,16 +183,16 @@ def generateDeepfakeECGs(numberOfECGs:       int = 1,
 
 # ###### Generate Deepfake ECG as files #####################################
 def generate(num_of_sample: int,
-             out_dir:       Union[str, pathlib.Path],
+             out_dir:       typing.Union[str, pathlib.Path],
              start_id:      int = 0,
-             runOnDevice:   Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu") -> None:
+             runOnDevice:   typing.Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu") -> None:
    """Generate multiple 8-lead ECG waveforms and save them as ASCII files
 
    Args:
       num_of_sample (int): Number of ECG samples to generate
-      out_dir (Union[str, pathlib.Path]): Output directory path where files will be saved
+      out_dir (typing.Union[str, pathlib.Path]): Output directory path where files will be saved
       start_id (int): Starting ID for the generated samples
-      runOnDevice (Literal["cpu", "cuda"]): Device to run generation on ("cpu" or "cuda")
+      runOnDevice (typing.Literal["cpu", "cuda"]): Device to run generation on ("cpu" or "cuda")
 
    Returns:
       None: Files are saved to the specified output directory with names {start_id}.asc to {start_id + num_of_sample - 1}.asc
@@ -205,7 +205,7 @@ def generate(num_of_sample: int,
 
 
 # ###### Generate Deepfake ECG as NumPy object ##############################
-def generate_as_numpy(runOnDevice: Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu") -> numpy.ndarray:
+def generate_as_numpy(runOnDevice: typing.Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu") -> numpy.ndarray:
    """Generate a single 8-lead ECG waveform using deepfakeecg model
 
    Args:

--- a/deepfakeecg/deepfakeecg.py
+++ b/deepfakeecg/deepfakeecg.py
@@ -199,6 +199,7 @@ def generateDeepfakeECGs(numberOfECGs:       int = 1,
            matplotlib.pyplot.xlabel("Time [s]")
            matplotlib.pyplot.ylabel("Amplitude [μV]")
            matplotlib.pyplot.grid(True)
+           matplotlib.pyplot.ylim(-1000, +1000)
            matplotlib.pyplot.savefig(outputFileName)
 
       # ------ Collect data in array ----------------------------------------

--- a/deepfakeecg/deepfakeecg.py
+++ b/deepfakeecg/deepfakeecg.py
@@ -1,3 +1,40 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# ==========================================================================
+#         ____                   __       _          _____ ____ ____
+#        |  _ \  ___  ___ _ __  / _| __ _| | _____  | ____/ ___/ ___|
+#        | | | |/ _ \/ _ \ '_ \| |_ / _` | |/ / _ \ |  _|| |  | |  _
+#        | |_| |  __/  __/ |_) |  _| (_| |   <  __/ | |__| |__| |_| |
+#        |____/ \___|\___| .__/|_|  \__,_|_|\_\___| |_____\____\____|
+#                        |_|
+#
+#                       --- Deepfake ECG Generator ---
+#                https://github.com/vlbthambawita/deepfake-ecg
+# ==========================================================================
+#
+# Generator Library
+# Copyright (C) 2021-2025 by Vajira Thambawita
+# Copyright (C) 2021-2025 by Turtle <erencemayez@gmail.com>
+# Copyright (C) 2025 by Thomas Dreibholz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Contact:
+# * Vajira Thambawita <vlbthambawita@gmail.com>
+# * Turtle <erencemayez@gmail.com>
+# * Thomas Dreibholz <dreibh@simula.no>
+
 import numpy
 import os
 import pathlib

--- a/deepfakeecg/deepfakeecg.py
+++ b/deepfakeecg/deepfakeecg.py
@@ -1,89 +1,49 @@
 import numpy
 import os
+import pathlib
 import sys
 import torch
-from tqdm    import tqdm
-from pathlib import Path
+import tqdm
 from typing  import Union, Literal
 
 from . import Generator
 
 
-def generate(num_of_sample: int, out_dir: Union[str, Path], start_id: int = 0,
-             runOnDevice: Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu") -> None:
-    """Generate multiple 8-lead ECG waveforms and save them as ASCII files
+# ###### Generate Deepfake ECG as files #####################################
+def generate(num_of_sample: int,
+             out_dir:       Union[str, pathlib.Path],
+             start_id:      int = 0,
+             runOnDevice:   Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu") -> None:
+   """Generate multiple 8-lead ECG waveforms and save them as ASCII files
 
-    Args:
-        num_of_sample (int): Number of ECG samples to generate
-        out_dir (Union[str, Path]): Output directory path where files will be saved
-        start_id (int): Starting ID for the generated samples
-        runOnDevice (Literal["cpu", "cuda"]): Device to run generation on ("cpu" or "cuda")
+   Args:
+      num_of_sample (int): Number of ECG samples to generate
+      out_dir (Union[str, pathlib.Path]): Output directory path where files will be saved
+      start_id (int): Starting ID for the generated samples
+      runOnDevice (Literal["cpu", "cuda"]): Device to run generation on ("cpu" or "cuda")
 
-    Returns:
-        None: Files are saved to the specified output directory with names {start_id}.asc to {start_id + num_of_sample - 1}.asc
-             Each file contains ECG data in ASCII format with shape (5000, 8) for leads [I, II, V1, V2, V3, V4, V5, V6]
+   Returns:
+      None: Files are saved to the specified output directory with names {start_id}.asc to {start_id + num_of_sample - 1}.asc
+      Each file contains ECG data in ASCII format with shape (5000, 8) for leads [I, II, V1, V2, V3, V4, V5, V6]
     """
-    root_dir = Path(__file__).parent
 
-    device = torch.device(runOnDevice)
-
-    netG = Generator()
-    checkpoint = torch.load(
-        os.path.join(root_dir, "checkpoints/g_stat.pt"),
-        map_location=device,
-        weights_only=True
-    )
-    netG.load_state_dict(checkpoint["stat_dict"])
-    netG.to(device)
-    netG.eval()
-
-    for i in tqdm(range(start_id, start_id + num_of_sample)):
-        noise = torch.Tensor(1, 8, 5000).uniform_(-1, 1)
-        noise = noise.to(device)
-        out = netG(noise)
-        out_rescaled = out * 6000
-        out_rescaled = out_rescaled.int()
-
-        out_rescaled_t = torch.t(out_rescaled.squeeze())
-
-        # asc_file = open("{}/{}.asc".format(asc_dir, i), 'ab')
-        np.savetxt("{}/{}.asc".format(out_dir, str(i)), out_rescaled_t.detach().cpu().numpy(), fmt='%i')
-        # asc_file.close()
+   generateDeepfakeECGs(num_of_sample, DATA_ECG8, 5000, OUTPUT_ASC,
+                        os.path.join(out_dir, "{number}.asc"), 0)
 
 
-def generate_as_numpy(runOnDevice: Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu"):
-    """Generate a single 8-lead ECG waveform using deepfakeecg model
+# ###### Generate Deepfake ECG as NumPy object ##############################
+def generate_as_numpy(runOnDevice: Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu") -> numpy.ndarray:
+   """Generate a single 8-lead ECG waveform using deepfakeecg model
 
-    Args:
-        runOnDevice (str): Device to run generation on ("cpu" or "cuda")
+   Args:
+       runOnDevice (str): Device to run generation on ("cpu" or "cuda")
 
-    Returns:
-        numpy.ndarray: Array of shape (5000, 8) containing the ECG data
-                      for leads [I, II, V1, V2, V3, V4, V5, V6]
+   Returns:
+       numpy.ndarray: Array of shape (5000, 8) containing the ECG data for leads [I, II, V1, V2, V3, V4, V5, V6]
     """
-    root_dir = Path(__file__).parent
-    device = torch.device(runOnDevice)
 
-    netG = Generator()
-    checkpoint = torch.load(
-        os.path.join(root_dir, "checkpoints/g_stat.pt"),
-        map_location=device,
-        weights_only=True
-    )
-    netG.load_state_dict(checkpoint["stat_dict"])
-    netG.to(device)
-    netG.eval()
-
-    noise = torch.Tensor(1, 8, 5000).uniform_(-1, 1)
-    noise = noise.to(device)
-    out = netG(noise)
-    out_rescaled = out * 6000
-    out_rescaled = out_rescaled.int()
-
-    # Convert to numpy and transpose to get (5000, 8) shape
-    data = out_rescaled.squeeze().t().detach().cpu().numpy()
-
-    return data
+   results = generateDeepfakeECGs(1, DATA_ECG8, 5000, OUTPUT_NUMPY)
+   return results[0]
 
 
 # ------ Constants ----------------------------------------
@@ -100,13 +60,13 @@ OUTPUT_CSV        = 3
 
 
 # ###### Generate Deepfake ECGs #############################################
-def generate_NEW(numberOfECGs:      int = 1,
-                 ecgType:           int = DATA_ECG8,
-                 ecgLength:         int = 5000,
-                 outputFormat:      int = OUTPUT_NUMPY,
-                 outputFilePattern: Union[str, Path] = None,
-                 outputStartID:     int = 0,
-                 runOnDevice:       Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu"):
+def generateDeepfakeECGs(numberOfECGs:      int = 1,
+                         ecgType:           int = DATA_ECG8,
+                         ecgLength:         int = 5000,
+                         outputFormat:      int = OUTPUT_NUMPY,
+                         outputFilePattern: Union[str, pathlib.Path] = None,
+                         outputStartID:     int = 0,
+                         runOnDevice:       Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu"):
    """Generate ECG waveforms using deepfakeecg model, with configurable
       data type (8-lead or 12-lead ECG) and output type (numpy, file).
 
@@ -119,7 +79,7 @@ def generate_NEW(numberOfECGs:      int = 1,
    """
 
    # ====== Initialise generator ============================================
-   root_dir = Path(__file__).parent
+   root_dir = pathlib.Path(__file__).parent
    device = torch.device(runOnDevice)
 
    generator = Generator()
@@ -142,11 +102,8 @@ def generate_NEW(numberOfECGs:      int = 1,
 
    # ====== Generate ECGs ===================================================
    results = [ ]
-   print(ecgType)
-   sys.exit(1)
    for i in tqdm.tqdm(range(outputStartID, outputStartID + numberOfECGs)):
       # ------ Create random noise  -----------------------------------------
-      # !!!!
       noise = torch.Tensor(1, 8, ecgLength, device = device).uniform_(-1, 1)
 
       # ------ Generate ECG -------------------------------------------------
@@ -199,7 +156,7 @@ def generate_NEW(numberOfECGs:      int = 1,
                          fmt       = '%i')
 
       # ------ Collect data in array ----------------------------------------
-      if outputFormat == OUTPUT_NUMPY:
+      elif outputFormat == OUTPUT_NUMPY:
          results.append(data)
       else:
          raise Exception('Invalid output format!')

--- a/deepfakeecg/deepfakeecg.py
+++ b/deepfakeecg/deepfakeecg.py
@@ -71,11 +71,23 @@ def generateDeepfakeECGs(numberOfECGs:       int = 1,
       data type (8-lead or 12-lead ECG) and output type (numpy, file).
 
    Args:
+      numberOfECGs (int): The number of ECGs to generate
+      ecgLengthInSeconds (int): The ECG length in seconds
+      outputFormat (int): The format of the output
+         OUTPUT_NUMPY: list of NumPy objects
+         OUTPUT_ASC: text, as in the original code
+         OUTPUT_CSV: CSV, with additional column for time stamp in milliseconds
+      outputFilePattern: Pattern for naming output files, with format() placeholder "number", e.g. 'ecg-{number:06d}.csv'
+      outputStartID: Start ID for file numbering
       runOnDevice (str): Device to run generation on ("cpu" or "cuda")
 
    Returns:
-      numpy.ndarray: Array of shape (ecgLength, 8) containing the ECG data
-                    for leads [I, II, V1, V2, V3, V4, V5, V6]
+      In case of outputFormat OUTPUT_NUMPY:
+         List of arrays of shape (ecgLength, n) containing the ECG data.
+         For ECG type DATA_ECG8:
+            numpy.ndarray: [I, II, V1, V2, V3, V4, V5, V6]
+         For ECG type DATA_ECG12:
+            numpy.ndarray: [I, II, V1, V2, V3, V4, V5, V6, III, aVL, aVR, aVF]
    """
 
    # ====== Initialise generator ============================================
@@ -142,7 +154,7 @@ def generateDeepfakeECGs(numberOfECGs:       int = 1,
                                      aVL.reshape(ecgLengthInSamples, 1),
                                      aVRL.reshape(ecgLengthInSamples, 1),
                                      aVF.reshape(ecgLengthInSamples, 1)
-                                    ) , 1 )
+                                   ) , 1 )
 
       # ------ Add time stamp for CSV output --------------------------------
       if outputFormat == OUTPUT_CSV:

--- a/examples/generate_as_numpy.py
+++ b/examples/generate_as_numpy.py
@@ -54,9 +54,9 @@ matplotlib.pyplot.plot(ecg_data[:, 5], label="V4")
 matplotlib.pyplot.plot(ecg_data[:, 6], label="V5")
 matplotlib.pyplot.plot(ecg_data[:, 7], label="V6")
 matplotlib.pyplot.legend()
-matplotlib.pyplot.title("Generated ECG - Lead I")
-matplotlib.pyplot.xlabel("Sample")
-matplotlib.pyplot.ylabel("Amplitude (μV)")
+matplotlib.pyplot.title("Generated ECG")
+matplotlib.pyplot.xlabel("Time [s]")
+matplotlib.pyplot.ylabel("Amplitude [μV]")
 matplotlib.pyplot.grid(True)
 
 # Print shape and basic stats

--- a/examples/generate_as_numpy.py
+++ b/examples/generate_as_numpy.py
@@ -12,7 +12,7 @@
 #                https://github.com/vlbthambawita/deepfake-ecg
 # ==========================================================================
 #
-# Command-Line Generator Tool
+# Deepfake ECG Example
 # Copyright (C) 2025 by Turtle <erencemayez@gmail.com>
 # Copyright (C) 2025 by Thomas Dreibholz
 #

--- a/examples/generate_as_numpy.py
+++ b/examples/generate_as_numpy.py
@@ -1,23 +1,34 @@
 #!/usr/bin/env python3
 
-import matplotlib.pyplot as plt
+import sys
+sys.path.append('..')
+
 import deepfakeecg
-import numpy as np
+import matplotlib.pyplot
+import numpy
 
 # Generate a single ECG sample
 ecg_data = deepfakeecg.generate_as_numpy()
 
 # Plot the first lead (Lead I)
-plt.figure(figsize=(15, 3))
-plt.plot(ecg_data[:, 0])
-plt.title("Generated ECG - Lead I")
-plt.xlabel("Sample")
-plt.ylabel("Amplitude (μV)")
-plt.grid(True)
+matplotlib.pyplot.figure(figsize=(15, 3))
+matplotlib.pyplot.plot(ecg_data[:, 0], label="Lead I")
+matplotlib.pyplot.plot(ecg_data[:, 1], label="Lead II")
+matplotlib.pyplot.plot(ecg_data[:, 2], label="V1")
+matplotlib.pyplot.plot(ecg_data[:, 3], label="V2")
+matplotlib.pyplot.plot(ecg_data[:, 4], label="V3")
+matplotlib.pyplot.plot(ecg_data[:, 5], label="V4")
+matplotlib.pyplot.plot(ecg_data[:, 6], label="V5")
+matplotlib.pyplot.plot(ecg_data[:, 7], label="V6")
+matplotlib.pyplot.legend()
+matplotlib.pyplot.title("Generated ECG - Lead I")
+matplotlib.pyplot.xlabel("Sample")
+matplotlib.pyplot.ylabel("Amplitude (μV)")
+matplotlib.pyplot.grid(True)
 
 # Print shape and basic stats
 print(f"ECG data shape: {ecg_data.shape}")
-print(f"Value range: [{np.min(ecg_data)}, {np.max(ecg_data)}]")
+print(f"Value range: [{numpy.min(ecg_data)}, {numpy.max(ecg_data)}]")
 print("\nLead order: [I, II, V1, V2, V3, V4, V5, V6]")
 
-plt.show()
+matplotlib.pyplot.show()

--- a/examples/generate_as_numpy.py
+++ b/examples/generate_as_numpy.py
@@ -1,4 +1,37 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# ==========================================================================
+#         ____                   __       _          _____ ____ ____
+#        |  _ \  ___  ___ _ __  / _| __ _| | _____  | ____/ ___/ ___|
+#        | | | |/ _ \/ _ \ '_ \| |_ / _` | |/ / _ \ |  _|| |  | |  _
+#        | |_| |  __/  __/ |_) |  _| (_| |   <  __/ | |__| |__| |_| |
+#        |____/ \___|\___| .__/|_|  \__,_|_|\_\___| |_____\____\____|
+#                        |_|
+#
+#                       --- Deepfake ECG Generator ---
+#                https://github.com/vlbthambawita/deepfake-ecg
+# ==========================================================================
+#
+# Command-Line Generator Tool
+# Copyright (C) 2025 by Turtle <erencemayez@gmail.com>
+# Copyright (C) 2025 by Thomas Dreibholz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Contact:
+# * Turtle <erencemayez@gmail.com>
+# * Thomas Dreibholz <dreibh@simula.no>
 
 import sys
 sys.path.append('..')

--- a/examples/generate_to_file.py
+++ b/examples/generate_to_file.py
@@ -1,6 +1,9 @@
 #!/usr/bin/env python3
 
-from deepfakeecg import generate
+import sys
+sys.path.append('..')
+
+import deepfakeecg
 import os
 
 # Create output directory if it doesn't exist
@@ -8,7 +11,7 @@ output_dir = "generated_ecgs"
 os.makedirs(output_dir, exist_ok=True)
 
 # Generate 5 ECG samples starting from ID 0
-generate(
+deepfakeecg.generate(
     num_of_sample=5,
     out_dir=output_dir,
     start_id=0

--- a/examples/generate_to_file.py
+++ b/examples/generate_to_file.py
@@ -12,7 +12,7 @@
 #                https://github.com/vlbthambawita/deepfake-ecg
 # ==========================================================================
 #
-# Command-Line Generator Tool
+# Deepfake ECG Example
 # Copyright (C) 2025 by Turtle <erencemayez@gmail.com>
 # Copyright (C) 2025 by Thomas Dreibholz
 #
@@ -45,9 +45,9 @@ os.makedirs(output_dir, exist_ok=True)
 
 # Generate 5 ECG samples starting from ID 0
 deepfakeecg.generate(
-    num_of_sample=5,
-    out_dir=output_dir,
-    start_id=0
+    num_of_sample = 5,
+    out_dir       = output_dir,
+    start_id      = 0
 )
 
 print(f"Generated 5 ECG samples in {output_dir}")

--- a/examples/generate_to_file.py
+++ b/examples/generate_to_file.py
@@ -1,4 +1,37 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# ==========================================================================
+#         ____                   __       _          _____ ____ ____
+#        |  _ \  ___  ___ _ __  / _| __ _| | _____  | ____/ ___/ ___|
+#        | | | |/ _ \/ _ \ '_ \| |_ / _` | |/ / _ \ |  _|| |  | |  _
+#        | |_| |  __/  __/ |_) |  _| (_| |   <  __/ | |__| |__| |_| |
+#        |____/ \___|\___| .__/|_|  \__,_|_|\_\___| |_____\____\____|
+#                        |_|
+#
+#                       --- Deepfake ECG Generator ---
+#                https://github.com/vlbthambawita/deepfake-ecg
+# ==========================================================================
+#
+# Command-Line Generator Tool
+# Copyright (C) 2025 by Turtle <erencemayez@gmail.com>
+# Copyright (C) 2025 by Thomas Dreibholz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Contact:
+# * Turtle <erencemayez@gmail.com>
+# * Thomas Dreibholz <dreibh@simula.no>
 
 import sys
 sys.path.append('..')

--- a/examples/generator-tool
+++ b/examples/generator-tool
@@ -1,28 +1,123 @@
-#/usr/bin/env python
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# ==========================================================================
+#         ____                   __       _          _____ ____ ____
+#        |  _ \  ___  ___ _ __  / _| __ _| | _____  | ____/ ___/ ___|
+#        | | | |/ _ \/ _ \ '_ \| |_ / _` | |/ / _ \ |  _|| |  | |  _
+#        | |_| |  __/  __/ |_) |  _| (_| |   <  __/ | |__| |__| |_| |
+#        |____/ \___|\___| .__/|_|  \__,_|_|\_\___| |_____\____\____|
+#                        |_|
+#
+#                       --- Deepfake ECG Generator ---
+#                https://github.com/vlbthambawita/deepfake-ecg
+# ==========================================================================
+#
+# Command-Line Generator Tool
+# Copyright (C) 2025 by Thomas Dreibholz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 
-import getopt, sys
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Contact: Thomas Dreibholz <dreibh@simula.no>
 
-def main():
-    try:
-        opts, args = getopt.getopt(sys.argv[1:], "ho:v", ["help", "output="])
-    except getopt.GetoptError as err:
-        # print help information and exit:
-        print(err)  # will print something like "option -a not recognized"
-        usage()
-        sys.exit(2)
-    output = None
-    verbose = False
-    for o, a in opts:
-        if o == "-v":
-            verbose = True
-        elif o in ("-h", "--help"):
-            usage()
-            sys.exit()
-        elif o in ("-o", "--output"):
-            output = a
-        else:
-            assert False, "unhandled option"
-    process(args, output=output, verbose=verbose)
+import sys
+sys.path.append('..')
 
-if __name__ == "__main__":
-    main()
+import deepfakeecg
+import getopt
+import matplotlib.pyplot
+import numpy
+
+
+# ###### Print usage and exit ###############################################
+def usage(exitCode = 0):
+   sys.stdout.write('Usage: ' + sys.argv[0] + ' [-t|--type ECG8|ECG12] [-f|--format numpy|ascii] [-o|--output filename_pattern]\n')
+   sys.exit(exitCode)
+
+
+# ###### Main program #######################################################
+
+# ====== Set defaults =======================================================
+ecgType           = deepfakeecg.DATA_ECG8
+ecgLength         = 5000
+ecgNumber         = 1
+outputFilePattern = 'ecg-{number}.data'
+outputFormat      = deepfakeecg.OUTPUT_CSV
+
+# ====== Handle arguments ===================================================
+try:
+   options, args = getopt.getopt(
+      sys.argv[1:],
+      't:n:o:f:',
+      [ 'ecgtype=',
+        'number=',
+        'length=',
+        'output=',
+        'format='] )
+   for option, optarg in options:
+      if option in ( '-t', '--type' ):
+         if optarg == 'ECG8':
+            ecgType = deepfakeecg.DATA_ECG8
+         elif optarg == 'ECG12':
+            ecgType = deepfakeecg.DATA_ECG12
+         else:
+            sys.stderr.write('ERROR: Invalid ECG type ' + optarg + '!\n')
+            sys.exit(1)
+      elif option in ( '-o', '--output' ):
+         outputPattern = optarg
+      elif option in ( '-n', '--number' ):
+         try:
+            ecgNumber = int(optarg)
+            if ecgNumber < 1:
+               raise Exception()
+         except:
+            sys.stderr.write('ERROR: Invalid ECG number ' + optarg + '!\n')
+            sys.exit(1)
+      elif option in ( '-l', '--length' ):
+         try:
+            ecgLength = int(optarg)
+            if ecgLength < 50:
+               raise Exception()
+         except:
+            sys.stderr.write('ERROR: Invalid ECG length ' + optarg + '!\n')
+            sys.exit(1)
+      elif option in ( '-f', '--format' ):
+         if optarg == 'numpy':
+            ecgType = deepfakeecg.OUTPUT_NUMPY
+         elif optarg == 'ascii':
+            ecgType = deepfakeecg.OUTPUT_ASC
+         else:
+            sys.stderr.write('ERROR: Invalid format ' + optarg + '!\n')
+            sys.exit(1)
+      else:
+         sys.stderr.write('ERROR: Invalid option ' + option + '!\n')
+         sys.exit(1)
+
+except getopt.GetoptError as error:
+   sys.stderr.write('ERROR: ' + error + '\n')
+   usage(1)
+if len(args) > 0:
+   usage(1)
+
+# ====== Generate ECGs ======================================================
+results = deepfakeecg.generate_NEW(ecgNumber, ecgType, ecgLength,
+                                   outputFormat, outputFilePattern,
+                                   0)
+
+# def generate_NEW(num_of_samples:      int = 1,
+#                  ecg__type:           int = DATA_ECG8,
+#                  ecg_length:          int = 5000,
+#                  output_format:       int = OUTPUT_NUMPY,
+#                  output_file_pattern: Union[str, Path] = None,
+#                  start_id:            int = 0,
+#                  run_device:          Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu"):

--- a/examples/generator-tool
+++ b/examples/generator-tool
@@ -51,7 +51,7 @@ def usage(exitCode = 0):
 ecgType           = deepfakeecg.DATA_ECG8
 ecgLength         = 5000
 ecgNumber         = 1
-outputFilePattern = 'ecg-{number}.data'
+outputFilePattern = 'ecg-{number}.csv'
 outputFormat      = deepfakeecg.OUTPUT_CSV
 
 # ====== Handle arguments ===================================================
@@ -96,6 +96,8 @@ try:
             ecgType = deepfakeecg.OUTPUT_NUMPY
          elif optarg == 'ascii':
             ecgType = deepfakeecg.OUTPUT_ASC
+         elif optarg == 'csv':
+            ecgType = deepfakeecg.OUTPUT_CSV
          else:
             sys.stderr.write('ERROR: Invalid format ' + optarg + '!\n')
             sys.exit(1)

--- a/examples/generator-tool
+++ b/examples/generator-tool
@@ -113,6 +113,6 @@ if len(args) > 0:
    usage(1)
 
 # ====== Generate ECGs ======================================================
-results = deepfakeecg.generate_NEW(ecgNumber, ecgType, ecgLength,
-                                   outputFormat, outputFilePattern,
-                                   0)
+results = deepfakeecg.generateDeepfakeECGs(ecgNumber, ecgType, ecgLength,
+                                           outputFormat, outputFilePattern,
+                                           0)

--- a/examples/generator-tool
+++ b/examples/generator-tool
@@ -58,30 +58,29 @@ outputFormat      = deepfakeecg.OUTPUT_CSV
 try:
    options, args = getopt.getopt(
       sys.argv[1:],
-      't:n:o:f:',
-      [ 'ecgtype=',
-        'number=',
+      'n:t:l:f:o:',
+      [ 'number=',
+        'ecgtype=',
         'length=',
-        'output=',
-        'format='] )
+        'format=',
+        'output='
+      ])
    for option, optarg in options:
-      if option in ( '-t', '--type' ):
-         if optarg == 'ECG8':
-            ecgType = deepfakeecg.DATA_ECG8
-         elif optarg == 'ECG12':
-            ecgType = deepfakeecg.DATA_ECG12
-         else:
-            sys.stderr.write('ERROR: Invalid ECG type ' + optarg + '!\n')
-            sys.exit(1)
-      elif option in ( '-o', '--output' ):
-         outputPattern = optarg
-      elif option in ( '-n', '--number' ):
+      if option in ( '-n', '--number' ):
          try:
             ecgNumber = int(optarg)
             if ecgNumber < 1:
                raise Exception()
          except:
             sys.stderr.write('ERROR: Invalid ECG number ' + optarg + '!\n')
+            sys.exit(1)
+      elif option in ( '-t', '--type' ):
+         if optarg == 'ECG8':
+            ecgType = deepfakeecg.DATA_ECG8
+         elif optarg == 'ECG12':
+            ecgType = deepfakeecg.DATA_ECG12
+         else:
+            sys.stderr.write('ERROR: Invalid ECG type ' + optarg + '!\n')
             sys.exit(1)
       elif option in ( '-l', '--length' ):
          try:
@@ -91,13 +90,15 @@ try:
          except:
             sys.stderr.write('ERROR: Invalid ECG length ' + optarg + '!\n')
             sys.exit(1)
+      elif option in ( '-o', '--output' ):
+         outputFilePattern = optarg
       elif option in ( '-f', '--format' ):
          if optarg == 'numpy':
-            ecgType = deepfakeecg.OUTPUT_NUMPY
+            outputFormat = deepfakeecg.OUTPUT_NUMPY
          elif optarg == 'ascii':
-            ecgType = deepfakeecg.OUTPUT_ASC
+            outputFormat = deepfakeecg.OUTPUT_ASC
          elif optarg == 'csv':
-            ecgType = deepfakeecg.OUTPUT_CSV
+            outputFormat = deepfakeecg.OUTPUT_CSV
          else:
             sys.stderr.write('ERROR: Invalid format ' + optarg + '!\n')
             sys.exit(1)
@@ -115,11 +116,3 @@ if len(args) > 0:
 results = deepfakeecg.generate_NEW(ecgNumber, ecgType, ecgLength,
                                    outputFormat, outputFilePattern,
                                    0)
-
-# def generate_NEW(num_of_samples:      int = 1,
-#                  ecg__type:           int = DATA_ECG8,
-#                  ecg_length:          int = 5000,
-#                  output_format:       int = OUTPUT_NUMPY,
-#                  output_file_pattern: Union[str, Path] = None,
-#                  start_id:            int = 0,
-#                  run_device:          Literal["cpu", "cuda"] = "cuda" if torch.cuda.is_available() else "cpu"):

--- a/examples/generator-tool
+++ b/examples/generator-tool
@@ -37,11 +37,12 @@ import deepfakeecg
 import getopt
 import matplotlib.pyplot
 import numpy
+import torch
 
 
 # ###### Print usage and exit ###############################################
 def usage(exitCode = 0):
-   sys.stdout.write('Usage: ' + sys.argv[0] + ' [-t|--type ECG8|ECG12] [-f|--format numpy|ascii] [-o|--output filename_pattern] [-s|--start-id number]\n')
+   sys.stdout.write('Usage: ' + sys.argv[0] + ' [-t|--type ECG8|ECG12] [-f|--format numpy|ascii] [-o|--output filename_pattern] [-s|--start-id number] [-d|--device cpu|cuda] [-v|--version]\n')
    sys.exit(exitCode)
 
 
@@ -54,18 +55,21 @@ ecgNumber         = 1
 outputFilePattern = 'ecg-{number}.csv'
 outputFormat      = deepfakeecg.OUTPUT_CSV
 outputStartID     = 0
+runOnDevice       = "cuda" if torch.cuda.is_available() else "cpu"
 
 # ====== Handle arguments ===================================================
 try:
    options, args = getopt.getopt(
       sys.argv[1:],
-      'n:t:l:f:o:s:',
+      'n:t:l:f:o:s:d:v',
       [ 'number=',
         'ecgtype=',
         'length=',
         'format=',
         'output=',
-        'startid='
+        'startid=',
+        'device=',
+        'version'
       ])
    for option, optarg in options:
       if option in ( '-n', '--number' ):
@@ -112,6 +116,14 @@ try:
          except:
             sys.stderr.write('ERROR: Invalid start ID ' + optarg + '!\n')
             sys.exit(1)
+      elif option in ( '-d', '--device' ):
+         runOnDevice = optarg
+      elif option in ( '-v', '--version' ):
+         sys.stdout.write('PyTorch version: ' + torch.__version__ + '\n')
+         sys.stdout.write('CUDA version:    ' + torch.version.cuda + '\n')
+         sys.stdout.write('CUDA available:  ' + ('yes' if torch.cuda.is_available() else 'no') + '\n')
+         sys.stdout.write('Device:          ' + runOnDevice + '\n')
+         sys.exit(1)
       else:
          sys.stderr.write('ERROR: Invalid option ' + option + '!\n')
          sys.exit(1)
@@ -125,4 +137,5 @@ if len(args) > 0:
 # ====== Generate ECGs ======================================================
 results = deepfakeecg.generateDeepfakeECGs(ecgNumber, ecgType, ecgLength,
                                            outputFormat, outputFilePattern,
-                                           outputStartID)
+                                           outputStartID,
+                                           runOnDevice)

--- a/examples/generator-tool
+++ b/examples/generator-tool
@@ -129,7 +129,7 @@ try:
          sys.exit(1)
 
 except getopt.GetoptError as error:
-   sys.stderr.write('ERROR: ' + error + '\n')
+   sys.stderr.write('ERROR: ' + str(error) + '\n')
    usage(1)
 if len(args) > 0:
    usage(1)

--- a/examples/generator-tool
+++ b/examples/generator-tool
@@ -49,7 +49,7 @@ def usage(exitCode = 0):
 
 # ====== Set defaults =======================================================
 ecgType           = deepfakeecg.DATA_ECG8
-ecgLength         = 5000
+ecgLength         = 10
 ecgNumber         = 1
 outputFilePattern = 'ecg-{number}.csv'
 outputFormat      = deepfakeecg.OUTPUT_CSV

--- a/examples/generator-tool
+++ b/examples/generator-tool
@@ -52,7 +52,7 @@ def usage(exitCode = 0):
 ecgType           = deepfakeecg.DATA_ECG8
 ecgLength         = 10
 ecgNumber         = 1
-outputFilePattern = 'ecg-{number}.csv'
+outputFilePattern = None
 outputFormat      = deepfakeecg.OUTPUT_CSV
 outputStartID     = 0
 runOnDevice       = "cuda" if torch.cuda.is_available() else "cpu"
@@ -91,7 +91,7 @@ try:
       elif option in ( '-l', '--length' ):
          try:
             ecgLength = int(optarg)
-            if ecgLength < 50:
+            if ecgLength < 1:
                raise Exception()
          except:
             sys.stderr.write('ERROR: Invalid ECG length ' + optarg + '!\n')
@@ -105,6 +105,8 @@ try:
             outputFormat = deepfakeecg.OUTPUT_ASC
          elif optarg == 'csv':
             outputFormat = deepfakeecg.OUTPUT_CSV
+         elif optarg == 'pdf':
+            outputFormat = deepfakeecg.OUTPUT_PDF
          else:
             sys.stderr.write('ERROR: Invalid format ' + optarg + '!\n')
             sys.exit(1)
@@ -133,6 +135,14 @@ except getopt.GetoptError as error:
    usage(1)
 if len(args) > 0:
    usage(1)
+
+if outputFilePattern == None:
+   if outputFormat == deepfakeecg.OUTPUT_CSV:
+      outputFilePattern = 'ecg-{number}.csv'
+   elif outputFormat == deepfakeecg.OUTPUT_PDF:
+      outputFilePattern = 'ecg-{number}.pdf'
+   else:
+      outputFilePattern = 'ecg-{number}.asc'
 
 # ====== Generate ECGs ======================================================
 results = deepfakeecg.generateDeepfakeECGs(ecgNumber, ecgType, ecgLength,

--- a/examples/generator-tool
+++ b/examples/generator-tool
@@ -41,7 +41,7 @@ import numpy
 
 # ###### Print usage and exit ###############################################
 def usage(exitCode = 0):
-   sys.stdout.write('Usage: ' + sys.argv[0] + ' [-t|--type ECG8|ECG12] [-f|--format numpy|ascii] [-o|--output filename_pattern]\n')
+   sys.stdout.write('Usage: ' + sys.argv[0] + ' [-t|--type ECG8|ECG12] [-f|--format numpy|ascii] [-o|--output filename_pattern] [-s|--start-id number]\n')
    sys.exit(exitCode)
 
 
@@ -53,17 +53,19 @@ ecgLength         = 10
 ecgNumber         = 1
 outputFilePattern = 'ecg-{number}.csv'
 outputFormat      = deepfakeecg.OUTPUT_CSV
+outputStartID     = 0
 
 # ====== Handle arguments ===================================================
 try:
    options, args = getopt.getopt(
       sys.argv[1:],
-      'n:t:l:f:o:',
+      'n:t:l:f:o:s:',
       [ 'number=',
         'ecgtype=',
         'length=',
         'format=',
-        'output='
+        'output=',
+        'startid='
       ])
    for option, optarg in options:
       if option in ( '-n', '--number' ):
@@ -102,6 +104,14 @@ try:
          else:
             sys.stderr.write('ERROR: Invalid format ' + optarg + '!\n')
             sys.exit(1)
+      elif option in ( '-s', '--startid' ):
+         try:
+            outputStartID = int(optarg)
+            if outputStartID < 0:
+               raise Exception()
+         except:
+            sys.stderr.write('ERROR: Invalid start ID ' + optarg + '!\n')
+            sys.exit(1)
       else:
          sys.stderr.write('ERROR: Invalid option ' + option + '!\n')
          sys.exit(1)
@@ -115,4 +125,4 @@ if len(args) > 0:
 # ====== Generate ECGs ======================================================
 results = deepfakeecg.generateDeepfakeECGs(ecgNumber, ecgType, ecgLength,
                                            outputFormat, outputFilePattern,
-                                           0)
+                                           outputStartID)

--- a/examples/generator-tool
+++ b/examples/generator-tool
@@ -42,7 +42,7 @@ import torch
 
 # ###### Print usage and exit ###############################################
 def usage(exitCode = 0):
-   sys.stdout.write('Usage: ' + sys.argv[0] + ' [-t|--type ECG8|ECG12] [-f|--format numpy|ascii] [-o|--output filename_pattern] [-s|--start-id number] [-d|--device cpu|cuda] [-v|--version]\n')
+   sys.stdout.write('Usage: ' + sys.argv[0] + ' [-t|--type ECG8|ECG12] [-f|--format numpy|ascii] [-o|--output filename_pattern] [-s|--start-id number] [-e|--leads {I,II,III,aVL,aVR,aVF,V1,V2,V3,V4,V5,V6}] [-d|--device cpu|cuda] [-v|--version]\n')
    sys.exit(exitCode)
 
 
@@ -55,19 +55,21 @@ ecgNumber         = 1
 outputFilePattern = None
 outputFormat      = deepfakeecg.OUTPUT_CSV
 outputStartID     = 0
+outputLeads       = [ 'I' ]
 runOnDevice       = "cuda" if torch.cuda.is_available() else "cpu"
 
 # ====== Handle arguments ===================================================
 try:
    options, args = getopt.getopt(
       sys.argv[1:],
-      'n:t:l:f:o:s:d:v',
+      'n:t:l:f:o:s:e:d:v',
       [ 'number=',
         'ecgtype=',
         'length=',
         'format=',
         'output=',
         'startid=',
+        'leads=',
         'device=',
         'version'
       ])
@@ -120,6 +122,8 @@ try:
             sys.exit(1)
       elif option in ( '-d', '--device' ):
          runOnDevice = optarg
+      elif option in ( '-e', '--leads' ):
+         outputLeads = optarg.split(',')
       elif option in ( '-v', '--version' ):
          sys.stdout.write('PyTorch version: ' + torch.__version__ + '\n')
          sys.stdout.write('CUDA version:    ' + torch.version.cuda + '\n')
@@ -147,5 +151,5 @@ if outputFilePattern == None:
 # ====== Generate ECGs ======================================================
 results = deepfakeecg.generateDeepfakeECGs(ecgNumber, ecgType, ecgLength,
                                            outputFormat, outputFilePattern,
-                                           outputStartID,
+                                           outputStartID, outputLeads,
                                            runOnDevice)

--- a/examples/generator-tool
+++ b/examples/generator-tool
@@ -1,0 +1,28 @@
+#/usr/bin/env python
+
+import getopt, sys
+
+def main():
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "ho:v", ["help", "output="])
+    except getopt.GetoptError as err:
+        # print help information and exit:
+        print(err)  # will print something like "option -a not recognized"
+        usage()
+        sys.exit(2)
+    output = None
+    verbose = False
+    for o, a in opts:
+        if o == "-v":
+            verbose = True
+        elif o in ("-h", "--help"):
+            usage()
+            sys.exit()
+        elif o in ("-o", "--output"):
+            output = a
+        else:
+            assert False, "unhandled option"
+    process(args, output=output, verbose=verbose)
+
+if __name__ == "__main__":
+    main()

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -1,4 +1,37 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+# ==========================================================================
+#         ____                   __       _          _____ ____ ____
+#        |  _ \  ___  ___ _ __  / _| __ _| | _____  | ____/ ___/ ___|
+#        | | | |/ _ \/ _ \ '_ \| |_ / _` | |/ / _ \ |  _|| |  | |  _
+#        | |_| |  __/  __/ |_) |  _| (_| |   <  __/ | |__| |__| |_| |
+#        |____/ \___|\___| .__/|_|  \__,_|_|\_\___| |_____\____\____|
+#                        |_|
+#
+#                       --- Deepfake ECG Generator ---
+#                https://github.com/vlbthambawita/deepfake-ecg
+# ==========================================================================
+#
+# Command-Line Generator Tool
+# Copyright (C) 2025 by Turtle <erencemayez@gmail.com>
+# Copyright (C) 2025 by Thomas Dreibholz
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+# Contact:
+# * Turtle <erencemayez@gmail.com>
+# * Thomas Dreibholz <dreibh@simula.no>
 
 import deepfakeecg
 

--- a/examples/simple.py
+++ b/examples/simple.py
@@ -12,7 +12,7 @@
 #                https://github.com/vlbthambawita/deepfake-ecg
 # ==========================================================================
 #
-# Command-Line Generator Tool
+# Deepfake ECG Example
 # Copyright (C) 2025 by Turtle <erencemayez@gmail.com>
 # Copyright (C) 2025 by Thomas Dreibholz
 #
@@ -35,4 +35,4 @@
 
 import deepfakeecg
 
-deepfakeecg.generate(5, ".", start_id=0)  # Generate 5 ECGs to the current folder starting from id=0
+deepfakeecg.generate(5, ".", start_id = 0)  # Generate 5 ECGs to the current folder starting from id=0


### PR DESCRIPTION
Improved function for configurable outputs of different types:
- Added a function generateDeepfakeECGs() with parametrisation of the desired output formats, ECG types, number of ECGs, etc.
- Made the ECG length configurable (in seconds)
- Added export option to CSV, with columns header line and column for the time stamp in milliseconds
- Added export option to PDF, which configurable list of leads to be plotted
- Added export option to ECG12, with computed values according to the formulae in https://ecgwaves.com/topic/ekg-ecg-leads-electrodes-systems-limb-chest-precordial/
- Replaced the existing functions by simple calls to generateDeepfakeECGs()
- Extended the NumPy plotting example
- Added a command-line tool "generator-tool" for creating and exporting ECGs, according to command-line parameters.